### PR TITLE
RM128835 Parametrizar pesquisa do XJUS para ignorar ACLs para GovSP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,14 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.21</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 
 		<dependency>
@@ -103,6 +108,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.build.timestamp.format>dd/MM/yyyy HH:mm</maven.build.timestamp.format>
+		<log4j.version>2.18.0</log4j.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>war</packaging>
 	<version>2.2.0</version>
 	<name>X-Jus Webapp</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<dependencies>
 		<dependency>
@@ -32,12 +32,8 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>7.9.1</version>
+			<version>7.17.5</version>
 		</dependency>
-
-		<!-- <dependency> <groupId>co.elastic.clients</groupId> <artifactId>elasticsearch-java</artifactId> 
-			<version>7.17.5</version> </dependency> <dependency> <groupId>com.fasterxml.jackson.core</groupId> 
-			<artifactId>jackson-databind</artifactId> <version>2.12.3</version> </dependency> -->
 
 		<dependency>
 			<groupId>com.auth0</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2.xjus</groupId>
 	<artifactId>x-jus</artifactId>
 	<packaging>war</packaging>
-	<version>2.2.0</version>
+	<version>2.3.0</version>
 	<name>X-Jus Webapp</name>
 	<url>https://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>7.17.5</version>
+			<version>7.15.2</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/br/jus/trf2/xjus/IXjus.java
+++ b/src/main/java/br/jus/trf2/xjus/IXjus.java
@@ -164,6 +164,8 @@ public interface IXjus {
 		public String page;
 		public String perpage;
 		public String acl;
+		public String fromDate;
+		public String toDate;
 	}
 
 	public class IndexIdxQueryGetResponse implements ISwaggerResponse {

--- a/src/main/java/br/jus/trf2/xjus/IndexIdxQueryGet.java
+++ b/src/main/java/br/jus/trf2/xjus/IndexIdxQueryGet.java
@@ -69,7 +69,7 @@ public class IndexIdxQueryGet implements IXjus.IIndexIdxQueryGet {
 				}
 			}
 
-			search.query(req.idx, req.filter, req.facets, page, perpage, acl, resp);
+			search.query(req.idx, req.filter, req.facets, page, perpage, acl, req.fromDate, req.toDate, resp);
 		}
 
 	}

--- a/src/main/java/br/jus/trf2/xjus/services/ISearch.java
+++ b/src/main/java/br/jus/trf2/xjus/services/ISearch.java
@@ -15,6 +15,9 @@ public interface ISearch {
 	void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl,
 			IndexIdxQueryGetResponse resp) throws Exception;
 
+	void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl, 
+			   String fromDate, String toDate, IndexIdxQueryGetResponse resp) throws Exception;
+
 	List<String> getDocumentIds(String indexName, String idStart, int maxRefresh) throws Exception;
 
 	Long count(String idx) throws Exception;

--- a/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
+++ b/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
@@ -357,11 +357,11 @@ public class JBossElastic implements ISearch {
         
 		if (acl == null)
 			acl = "PUBLIC";
-		String[] acls = ( !Prop.isGovSP() ) ? acl.split(";") : new String[]{ };
+		String[] acls = Prop.getBool("verify.acls") ? acl.split(";") : new String[]{ };
 		for (String s : acls) {
 			boolQueryBuilder.should(new TermQueryBuilder("acl", s));
 		}
-		boolQueryBuilder.minimumShouldMatch(( !Prop.isGovSP() ) ? 1 : 0);
+		boolQueryBuilder.minimumShouldMatch(Prop.getBool("verify.acls") ? 1 : 0);
 		searchSourceBuilder.query(boolQueryBuilder);
 
 		searchRequest.source(searchSourceBuilder);

--- a/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
+++ b/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
@@ -344,13 +344,14 @@ public class JBossElastic implements ISearch {
 			}
 		}
 
+
 		if (acl == null)
 			acl = "PUBLIC";
-		String[] acls = acl.split(";");
+		String[] acls = ( !Prop.isGovSP() ) ? acl.split(";") : new String[]{ };
 		for (String s : acls) {
 			boolQueryBuilder.should(new TermQueryBuilder("acl", s));
 		}
-		boolQueryBuilder.minimumShouldMatch(1);
+		boolQueryBuilder.minimumShouldMatch(( !Prop.isGovSP() ) ? 1 : 0);
 		searchSourceBuilder.query(boolQueryBuilder);
 
 		searchRequest.source(searchSourceBuilder);

--- a/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
+++ b/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
@@ -357,6 +357,7 @@ public class JBossElastic implements ISearch {
         
 		if (acl == null)
 			acl = "PUBLIC";
+		/* Caso propriedade verify.acls esteja com false, a verificação das ACLs será ignorada na pesquisa */
 		String[] acls = Prop.getBool("verify.acls") ? acl.split(";") : new String[]{ };
 		for (String s : acls) {
 			boolQueryBuilder.should(new TermQueryBuilder("acl", s));

--- a/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
+++ b/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
@@ -6,10 +6,7 @@ import java.io.StringReader;
 import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import javax.annotation.PreDestroy;
 
@@ -299,8 +296,13 @@ public class JBossElastic implements ISearch {
 	}
 
 	@Override
+	public void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl, IndexIdxQueryGetResponse resp) throws Exception {
+		this.query(idx, filter, facets, page, perpage, acl, null, null, resp);
+	}
+	
+	@Override
 	public void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl,
-			IndexIdxQueryGetResponse resp) throws Exception {
+					  String fromDate, String toDate, IndexIdxQueryGetResponse resp) throws Exception {
 		SearchRequest searchRequest = new SearchRequest(idx);
 
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
@@ -333,18 +335,26 @@ public class JBossElastic implements ISearch {
 		BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
 		boolQueryBuilder.must(new QueryStringQueryBuilder(filter));
 
-		if (facets != null && !facets.trim().isEmpty()) {
-			for (String f : facets.split(",")) {
-				String[] a = f.split(":", 3);
+        if (facets != null && !facets.trim().isEmpty()) {
+            for (String f : facets.split(",")) {
+                String[] a = f.split(":", 2);
 
-				if (a.length == 3)
-					addRangeFilter(a, boolQueryBuilder);
-				else if (a.length == 2)
-					boolQueryBuilder.must(new TermQueryBuilder(a[0], a[1]));
-			}
+                boolQueryBuilder.must(new TermQueryBuilder(a[0], a[1]));
+            }
+        }
+
+        if (fromDate != null && !fromDate.trim().isEmpty()) {
+            BoolQueryBuilder rangeStartQuery = new BoolQueryBuilder()
+					.should(QueryBuilders.rangeQuery("date").from(fromDate));
+			boolQueryBuilder.filter(rangeStartQuery);
+        }
+
+		if (toDate != null && !toDate.trim().isEmpty()) {
+			BoolQueryBuilder rangeEndQuery = new BoolQueryBuilder()
+					.should(QueryBuilders.rangeQuery("date").to(toDate));
+			boolQueryBuilder.filter(rangeEndQuery);
 		}
-
-
+        
 		if (acl == null)
 			acl = "PUBLIC";
 		String[] acls = ( !Prop.isGovSP() ) ? acl.split(";") : new String[]{ };

--- a/src/main/java/br/jus/trf2/xjus/util/Prop.java
+++ b/src/main/java/br/jus/trf2/xjus/util/Prop.java
@@ -54,10 +54,6 @@ public class Prop {
 		return Arrays.asList(p.split(","));
 	}
 
-	public static boolean isGovSP() {
-		return "GOVSP".equals(get("/x-jus.local"));
-	}
-
 	public static Date getData(String nome) {
 		DateFormat formatter = new SimpleDateFormat("dd/MM/yy");
 
@@ -84,25 +80,13 @@ public class Prop {
 
 		provider.addRestrictedProperty("status.dir", "/var/tmp");
 		provider.addPublicProperty("indexes");
-		provider.addPublicProperty("/x-jus.local", null);
+		provider.addPublicProperty("verify.acls", "true");
 		for (String i : getList("indexes")) {
 			provider.addRestrictedProperty("index." + i + ".api");
-			
-			/* Ativando indexação caso não seja GovSP */
-			if (!isGovSP()) {
-				provider.addPublicProperty("index." + i + ".active", "true");
-				provider.addPublicProperty("index." + i + ".build.docs.per.min", "10");
-				provider.addPublicProperty("index." + i + ".refresh.docs.per.min", "5");
-			} else {
-				/* 
-				* Desativando indexação caso seja GovSP. 
-				* Nesse caso o processo de indexação será realizado externamente pelo Logstash. 
-				* O XJUS passará a atuar somente na pesquisa da base previamente indexada. 
-				* */
-				provider.addPublicProperty("index." + i + ".active", "false");
-				provider.addPublicProperty("index." + i + ".build.docs.per.min", "0");
-				provider.addPublicProperty("index." + i + ".refresh.docs.per.min", "0");
-			}
+
+			provider.addPublicProperty("index." + i + ".active", "true");
+			provider.addPublicProperty("index." + i + ".build.docs.per.min", "10");
+			provider.addPublicProperty("index." + i + ".refresh.docs.per.min", "5");
 
 			provider.addPublicProperty("index." + i + ".descr", "");
 			provider.addPublicProperty("index." + i + ".build.docs.per.min.non.working.hours",

--- a/src/main/java/br/jus/trf2/xjus/util/Prop.java
+++ b/src/main/java/br/jus/trf2/xjus/util/Prop.java
@@ -84,20 +84,34 @@ public class Prop {
 
 		provider.addRestrictedProperty("status.dir", "/var/tmp");
 		provider.addPublicProperty("indexes");
+		provider.addPublicProperty("/x-jus.local", null);
 		for (String i : getList("indexes")) {
 			provider.addRestrictedProperty("index." + i + ".api");
-			provider.addPublicProperty("index." + i + ".active", "true");
+			
+			/* Ativando indexação caso não seja GovSP */
+			if (!isGovSP()) {
+				provider.addPublicProperty("index." + i + ".active", "true");
+				provider.addPublicProperty("index." + i + ".build.docs.per.min", "10");
+				provider.addPublicProperty("index." + i + ".refresh.docs.per.min", "5");
+			} else {
+				/* 
+				* Desativando indexação caso seja GovSP. 
+				* Nesse caso o processo de indexação será realizado externamente pelo Logstash. 
+				* O XJUS passará a atuar somente na pesquisa da base previamente indexada. 
+				* */
+				provider.addPublicProperty("index." + i + ".active", "false");
+				provider.addPublicProperty("index." + i + ".build.docs.per.min", "0");
+				provider.addPublicProperty("index." + i + ".refresh.docs.per.min", "0");
+			}
+
 			provider.addPublicProperty("index." + i + ".descr", "");
-			provider.addPublicProperty("index." + i + ".build.docs.per.min", "10");
 			provider.addPublicProperty("index." + i + ".build.docs.per.min.non.working.hours",
 					provider.getProp("index." + i + ".build.docs.per.min"));
-			provider.addPublicProperty("index." + i + ".refresh.docs.per.min", "5");
 			provider.addPublicProperty("index." + i + ".refresh.docs.per.min.non.working.hours",
 					provider.getProp("index." + i + ".refresh.docs.per.min"));
 			provider.addPrivateProperty("index." + i + ".secret");
 			provider.addPrivateProperty("index." + i + ".token");
 			provider.addPublicProperty("index." + i + ".query.json", "{}");
 		}
-		provider.addPublicProperty("/x-jus.local", null);
 	}
 }

--- a/src/main/java/br/jus/trf2/xjus/util/Prop.java
+++ b/src/main/java/br/jus/trf2/xjus/util/Prop.java
@@ -54,6 +54,10 @@ public class Prop {
 		return Arrays.asList(p.split(","));
 	}
 
+	public static boolean isGovSP() {
+		return "GOVSP".equals(get("/x-jus.local"));
+	}
+
 	public static Date getData(String nome) {
 		DateFormat formatter = new SimpleDateFormat("dd/MM/yy");
 
@@ -94,5 +98,6 @@ public class Prop {
 			provider.addPrivateProperty("index." + i + ".token");
 			provider.addPublicProperty("index." + i + ".query.json", "{}");
 		}
+		provider.addPublicProperty("/x-jus.local", null);
 	}
 }

--- a/src/main/java/br/jus/trf2/xjus/util/Prop.java
+++ b/src/main/java/br/jus/trf2/xjus/util/Prop.java
@@ -80,6 +80,9 @@ public class Prop {
 
 		provider.addRestrictedProperty("status.dir", "/var/tmp");
 		provider.addPublicProperty("indexes");
+		/* Adição da propriedade verify.acls para configuração se as ACLs serão verificadas ou não na pesquisa 
+		* Caso propriedade verify.acls esteja com false, a verificação das ACLs será ignorada na pesquisa
+		* */
 		provider.addPublicProperty("verify.acls", "true");
 		for (String i : getList("indexes")) {
 			provider.addRestrictedProperty("index." + i + ".api");

--- a/src/main/resources/br/jus/trf2/xjus/services/jboss/create-index-request.json
+++ b/src/main/resources/br/jus/trf2/xjus/services/jboss/create-index-request.json
@@ -33,6 +33,9 @@
 			"date": {
 				"type": "date"
 			},
+			"field_data": {
+				"type": "date"
+			},
 			"code": {
 				"type": "keyword"
 			},


### PR DESCRIPTION
### Parametrizar pesquisa do XJUS para ignorar ACLs para GOVSP

Atualmente a pesquisa realizada através do XJUS retorna somente os resultados dos documentos que o usuário tem acesso. Foi solicitado a alteração desse comportamento para obter todos resultados independente do nível de acesso armazenado nas ACLs, visando deixar a pesquisa semelhante ao existente na pesquisa avançada para GovSP.

#### Resumo da implementação

1. Adição da propriedade verify.acls para configuração se as ACLs serão verificadas ou não na pesquisa
3. Desativação da pesquisa utilizando ACLs
4. Atualização do cliente REST RestHighLevelClient do ElasticSearch
5. Atualização do Log4j2
6. FIX: Mapping field_data para o tipo date
7. FIX: Facets contendo caractere ":" 
Método addRangeFilter estava funcionando incorretamente quando outros facets continham o caractere ":" no conteúdo.
Foi preferível adicionar os parâmetros fromDate e toDate para realizar a pesquisa com intervalos de data e não impactar os demais facets.
