### PR TITLE
RM129347 Adição do parâmetro code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.trf2.xjus</groupId>
 	<artifactId>x-jus</artifactId>
 	<packaging>war</packaging>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<name>X-Jus Webapp</name>
 	<url>https://maven.apache.org</url>
 

--- a/src/main/java/br/jus/trf2/xjus/IXjus.java
+++ b/src/main/java/br/jus/trf2/xjus/IXjus.java
@@ -164,6 +164,7 @@ public interface IXjus {
 		public String page;
 		public String perpage;
 		public String acl;
+		public String code;
 		public String fromDate;
 		public String toDate;
 	}

--- a/src/main/java/br/jus/trf2/xjus/IndexIdxQueryGet.java
+++ b/src/main/java/br/jus/trf2/xjus/IndexIdxQueryGet.java
@@ -69,7 +69,7 @@ public class IndexIdxQueryGet implements IXjus.IIndexIdxQueryGet {
 				}
 			}
 
-			search.query(req.idx, req.filter, req.facets, page, perpage, acl, req.fromDate, req.toDate, resp);
+			search.query(req.idx, req.filter, req.facets, page, perpage, acl, req.code, req.fromDate, req.toDate, resp);
 		}
 
 	}

--- a/src/main/java/br/jus/trf2/xjus/services/ISearch.java
+++ b/src/main/java/br/jus/trf2/xjus/services/ISearch.java
@@ -16,7 +16,7 @@ public interface ISearch {
 			IndexIdxQueryGetResponse resp) throws Exception;
 
 	void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl, 
-			   String fromDate, String toDate, IndexIdxQueryGetResponse resp) throws Exception;
+			   String code, String fromDate, String toDate, IndexIdxQueryGetResponse resp) throws Exception;
 
 	List<String> getDocumentIds(String indexName, String idStart, int maxRefresh) throws Exception;
 

--- a/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
+++ b/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
@@ -297,12 +297,12 @@ public class JBossElastic implements ISearch {
 
 	@Override
 	public void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl, IndexIdxQueryGetResponse resp) throws Exception {
-		this.query(idx, filter, facets, page, perpage, acl, null, null, resp);
+		this.query(idx, filter, facets, page, perpage, acl, null, null, null, resp);
 	}
 	
 	@Override
 	public void query(String idx, String filter, String facets, Integer page, Integer perpage, String acl,
-					  String fromDate, String toDate, IndexIdxQueryGetResponse resp) throws Exception {
+					  String code, String fromDate, String toDate, IndexIdxQueryGetResponse resp) throws Exception {
 		SearchRequest searchRequest = new SearchRequest(idx);
 
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
@@ -343,6 +343,12 @@ public class JBossElastic implements ISearch {
             }
         }
 
+		if (code != null && !code.trim().isEmpty()) {
+			QueryStringQueryBuilder queryStringQueryBuilder = new QueryStringQueryBuilder("*" + code);
+			queryStringQueryBuilder.defaultField("code");
+			boolQueryBuilder.must(queryStringQueryBuilder);
+		}
+		
         if (fromDate != null && !fromDate.trim().isEmpty()) {
             BoolQueryBuilder rangeStartQuery = new BoolQueryBuilder()
 					.should(QueryBuilders.rangeQuery("date").from(fromDate));

--- a/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
+++ b/src/main/java/br/jus/trf2/xjus/services/jboss/JBossElastic.java
@@ -346,7 +346,7 @@ public class JBossElastic implements ISearch {
 		if (code != null && !code.trim().isEmpty()) {
 			QueryStringQueryBuilder queryStringQueryBuilder = new QueryStringQueryBuilder("*" + code);
 			queryStringQueryBuilder.defaultField("code");
-			boolQueryBuilder.must(queryStringQueryBuilder);
+			boolQueryBuilder.filter(queryStringQueryBuilder);
 		}
 		
         if (fromDate != null && !fromDate.trim().isEmpty()) {

--- a/src/main/resources/br/jus/trf2/xjus/swagger.yaml
+++ b/src/main/resources/br/jus/trf2/xjus/swagger.yaml
@@ -48,6 +48,9 @@ paths:
         - $ref: "#/parameters/facets"
         - $ref: "#/parameters/page"
         - $ref: "#/parameters/perpage"
+        - $ref: "#/parameters/fromDate"
+        - $ref: "#/parameters/toDate"
+        - $ref: "#/parameters/code"
         - $ref: "#/parameters/acl"
       responses:
         200:
@@ -273,6 +276,24 @@ parameters:
     description: Quantidade de itens por página.
     required: true
     type: string
+  fromDate:
+    name: fromDate
+    in: query
+    description: Intervalo de data inicial.
+    required: false
+    type: string
+  toDate:
+    name:   toDate
+    in: query
+    description: Intervalo de data final.
+    required: false
+    type: string
+  code:
+    name: code
+    in: query
+    description: Código que contenha nos itens pesquisados.
+    required: false
+    type: string  
   acl:
     name: acl
     in: query


### PR DESCRIPTION
### Adição do parâmetro code para filtrar a pesquisa pela Sigla ou Número de Expediente

Melhoria na pesquisa do XJUS adicionando o parâmetro `code` no endpoint query para possibilitar filtrar a os resultados da pesquisa utilizando a Sigla ou Número de Expediente.
Atualmente o endpoint query não possibilita filtrar a pesquisa utilizando o campo `code` já que esse não é um `facet`.


#### Resumo da implementação

1. Adição do parâmetro code no método query da classe JBossElastic
2. Atualização dos parâmetros code, fromDate e toDate no Swagger

#### Conclusão

Após a implementação, foi possível realizar pesquisas utilizando o campo Número de Expediente na tela de Pesquisa Avançada utilizando o XJUS.